### PR TITLE
Redirect WP Frontend URL access to NextJS URL

### DIFF
--- a/inc/links.php
+++ b/inc/links.php
@@ -136,11 +136,9 @@ add_filter( 'rest_prepare_post', __NAMESPACE__ . '\set_headless_rest_preview_lin
 /**
  * Redirects non-API requests for public URLs to the specified front-end URL.
  *
- * @see https://github.com/wpengine/faustjs/blob/canary/plugins/wpe-headless/includes/deny-public-access/callbacks.php
- *
+ * @see https://github.com/wpengine/faustjs/blob/aaad74cd6edac536a1df405552256ca66575c8cd/plugins/wpe-headless/includes/deny-public-access/callbacks.php#L20
+ * @since NEXT
  * @param object $query The current query.
- *
- * @return void
  */
 function deny_public_access( $query ) {
 	if (

--- a/inc/links.php
+++ b/inc/links.php
@@ -159,6 +159,13 @@ function deny_public_access( $query ) {
 	// Get the request uri with query params.
 	$request_uri = home_url( add_query_arg( null, null ) );
 
+	// Return if dealing with upload URL.
+	$uploads_path = wp_upload_dir();
+
+	if ( false !== stristr( $request_uri, $uploads_path['baseurl'] ) ) {
+		return;
+	}
+
 	$response_code = 302;
 	$redirect_url  = str_replace( trailingslashit( get_home_url() ), $frontend_uri, $request_uri );
 

--- a/inc/links.php
+++ b/inc/links.php
@@ -137,6 +137,7 @@ add_filter( 'rest_prepare_post', __NAMESPACE__ . '\set_headless_rest_preview_lin
  * Redirects non-API requests for public URLs to the specified front-end URL.
  *
  * @see https://github.com/wpengine/faustjs/blob/aaad74cd6edac536a1df405552256ca66575c8cd/plugins/wpe-headless/includes/deny-public-access/callbacks.php#L20
+ * @author WebDevStudios
  * @since NEXT
  * @param object $query The current query.
  */


### PR DESCRIPTION
Closes: https://github.com/WebDevStudios/wds-headless-wordpress/issues/23

**Description**

This PR redirects access to WP Frontend URL to its NextJS URL.

**Note**

The WP Frontend URL stay as it is in the content and not replaced with the NextJS URL. We are still trying to figure out whats the best approach to fix this. 