### PR TITLE
Feature/778 link replacement

### DIFF
--- a/inc/links.php
+++ b/inc/links.php
@@ -109,18 +109,24 @@ function set_headless_rest_preview_link( WP_REST_Response $response, WP_Post $po
 		// Handle special-case pages.
 		$error_page = get_field( 'error_404_page', 'option' );
 
+		// Remove excess slash from end of frontend domain.
+		$base_url = rtrim( $base_url, '/' );
 
 		if ( $post->ID === $error_page->ID ) {
 
 			// Return 404 URL for error page.
 			$response->data['link'] = "{$base_url}/404";
 		} else {
+			$permalink = get_permalink( $post );
+			$site_url  = get_site_url();
 
-			// Remove excess slash from end of base URL.
-			$base_url = rtrim( $base_url, '/' );
+			// Replace site URL if present.
+			if ( false !== stristr( $permalink, $site_url ) ) {
+				$permalink = str_ireplace( $site_url, $base_url, $permalink );
+			}
 
 			// Return URL based on post name.
-			$response->data['link'] = "{$base_url}/{$post->post_name}";
+			$response->data['link'] = $permalink;
 		}
 	}
 

--- a/inc/links.php
+++ b/inc/links.php
@@ -139,6 +139,7 @@ add_filter( 'rest_prepare_post', __NAMESPACE__ . '\set_headless_rest_preview_lin
  * Override links within post content on save to point to FE.
  *
  * @author WebDevStudios
+ * @since NEXT
  * @param int $post_id Post ID.
  */
 function override_post_links( $post_id ) {

--- a/inc/links.php
+++ b/inc/links.php
@@ -107,14 +107,10 @@ function set_headless_rest_preview_link( WP_REST_Response $response, WP_Post $po
 		$base_url = HEADLESS_FRONTEND_URL;
 
 		// Handle special-case pages.
-		$homepage_id   = intval( get_field( 'homepage', 'option' ) );
-		$error_page_id = get_field( 'error_404_page', 'option' );
+		$error_page = get_field( 'error_404_page', 'option' );
 
-		if ( $post->ID === $homepage_id ) {
 
-			// Return root FE URL for homepage.
-			$response->data['link'] = $base_url;
-		} elseif ( $post->ID === $error_page_id ) {
+		if ( $post->ID === $error_page->ID ) {
 
 			// Return 404 URL for error page.
 			$response->data['link'] = "{$base_url}/404";

--- a/inc/links.php
+++ b/inc/links.php
@@ -193,7 +193,7 @@ function override_post_links( $post_id ) {
 }
 add_action( 'save_post', __NAMESPACE__ . '\override_post_links' );
 
-/*
+/**
  * Redirects non-API requests for public URLs to the specified front-end URL.
  *
  * @see https://github.com/wpengine/faustjs/blob/aaad74cd6edac536a1df405552256ca66575c8cd/plugins/wpe-headless/includes/deny-public-access/callbacks.php#L20


### PR DESCRIPTION
Closes #3
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/778
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/633

Removes "homepage" special case handling since that's not implemented on this project.
Fixes "error page" special case handling.
Fixes permalink replacement to avoid breaking hierarchical and custom post types.
Adds hook to replace content links on post save.