### PR TITLE
Fix/858 options

### DIFF
--- a/inc/links.php
+++ b/inc/links.php
@@ -107,12 +107,13 @@ function set_headless_rest_preview_link( WP_REST_Response $response, WP_Post $po
 		$base_url = HEADLESS_FRONTEND_URL;
 
 		// Handle special-case pages.
-		$error_page = get_field( 'error_404_page', 'option' );
+		$options    = get_option( WDS_HEADLESS_CORE_OPTION_NAME );
+		$error_page = is_array( $options ) ? $options['error_404_page'] : null;
 
 		// Remove excess slash from end of frontend domain.
 		$base_url = rtrim( $base_url, '/' );
 
-		if ( $post->ID === $error_page->ID ) {
+		if ( $error_page && $post->ID === $error_page->ID ) {
 
 			// Return 404 URL for error page.
 			$response->data['link'] = "{$base_url}/404";

--- a/wds-headless-core.php
+++ b/wds-headless-core.php
@@ -5,7 +5,7 @@
  * Description: The core WordPress plugin for the Next.js WordPress Starter.
  * Author: WebDevStudios <contact@webdevstudios.com>
  * Author URI: https://webdevstudios.com
- * Version: 2.0.0
+ * Version: 2.0.1
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * License: GPL-2
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define constants.
 define( 'WDS_HEADLESS_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WDS_HEADLESS_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'WDS_HEADLESS_CORE_VERSION', '2.0.0' );
+define( 'WDS_HEADLESS_CORE_VERSION', '2.0.1' );
 define( 'WDS_HEADLESS_CORE_OPTION_NAME', 'headless_config' );
 
 // Register de/activation hooks.


### PR DESCRIPTION
Closes https://github.com/WebDevStudios/nextjs-wordpress-starter/issues/858

### Description

Updates options handling to use WP functions instead of ACF ones

### Screenshot

n/a

### Verification

1. disable ACF Pro
2. create/edit a post and confirm there are no errors
