### PR TITLE
update revalidation functionality

### DIFF
--- a/inc/links.php
+++ b/inc/links.php
@@ -12,57 +12,6 @@ namespace WDS_Headless_Core;
 use \WP_Post;
 use \WP_REST_Response;
 
-
-/**
- * Flush the frontend cache when a post is updated.
- *
- * @see https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#using-on-demand-revalidation
- * @since 2.1.3
- * @author WebDevStudios
- */
-function on_demand_revalidation() {
-
-	// These constsants are required. If they're not here, bail...
-	if ( ! defined( 'HEADLESS_FRONTEND_URL' ) || ! defined( 'PREVIEW_SECRET_TOKEN' ) ) {
-		return;
-	}
-
-	// Attempt to get post object.
-	$post = get_post();
-
-	// No post object? Bail...
-	if ( ! $post ) {
-		return;
-	}
-
-	// Define the post slug.
-	$slug = str_replace( HEADLESS_FRONTEND_URL, '', get_the_permalink( $post->ID ) );
-
-	// No slug? Bail...
-	if ( ! $slug ) {
-		return;
-	}
-
-	// Send the POST request to the frontend.
-	wp_remote_post(
-		HEADLESS_FRONTEND_URL . 'api/wordpress/revalidate',
-		[
-			'blocking' => true,
-			'headers'  => [
-				'Content-Type' => 'application/json',
-				'Expect'       => '',
-			],
-			'body'     => wp_json_encode(
-				[
-					'secret' => PREVIEW_SECRET_TOKEN,
-					'slug'   => "/${slug}",
-				]
-			),
-		]
-	);
-}
-add_action( 'post_updated', __NAMESPACE__ . '\on_demand_revalidation', 10, 3 );
-
 /**
  * Customize the preview button in the WordPress admin to point to the headless client.
  *

--- a/inc/revalidation.php
+++ b/inc/revalidation.php
@@ -6,6 +6,7 @@
  * @package WDS_Headless_Core
  * @since 2.1.3
  */
+
 namespace WDS_Headless_Core;
 
 use \WP_Post;
@@ -20,20 +21,18 @@ use \WP_Post;
  * @see https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#using-on-demand-revalidation
  * @since 2.1.3
  * @author WebDevStudios
- * @param int $post_ID  The post ID.
+ * @param int     $post_ID  The post ID.
  * @param WP_Post $post The post object.
  */
 function on_demand_revalidation( $post_ID, WP_Post $post ) {
 
 	// These constsants are required. If they're not here, bail...
 	if ( ! defined( 'HEADLESS_FRONTEND_URL' ) || ! defined( 'PREVIEW_SECRET_TOKEN' ) ) {
-		error_log( 'Missing constants for on demand revalidation.' );
 		return;
 	}
 
 	// No post ID? Bail...
 	if ( ! $post_ID ) {
-		error_log( 'Missing post ID for on demand revalidation.' );
 		return;
 	}
 
@@ -42,7 +41,6 @@ function on_demand_revalidation( $post_ID, WP_Post $post ) {
 
 	// No slug? Bail...
 	if ( ! $slug ) {
-		error_log( 'Missing post slug for on demand revalidation.' );
 		return;
 	}
 
@@ -55,7 +53,7 @@ function on_demand_revalidation( $post_ID, WP_Post $post ) {
 				'Content-Type' => 'application/json',
 				'Expect'       => '',
 			],
-			'body' => wp_json_encode(
+			'body'     => wp_json_encode(
 				[
 					'secret' => PREVIEW_SECRET_TOKEN,
 					'slug'   => "/${slug}",
@@ -68,8 +66,8 @@ function on_demand_revalidation( $post_ID, WP_Post $post ) {
 	$response_code = wp_remote_retrieve_response_code( $response );
 
 	// If there is an error, log it.
-	if ( $response_code !== 200 ) {
-		error_log( 'Failed to revalidate cache for post ' . $slug . '.' );
+	if ( 200 !== $response_code ) {
+		return;
 	}
 }
 add_action( 'edit_post', __NAMESPACE__ . '\on_demand_revalidation', 10, 3 );

--- a/inc/revalidation.php
+++ b/inc/revalidation.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Revalidation functionality.
+ *
+ * @author WebDevStudios
+ * @package WDS_Headless_Core
+ * @since 2.1.3
+ */
+namespace WDS_Headless_Core;
+
+use \WP_Post;
+
+/**
+ * Flush the frontend cache when a post is updated.
+ *
+ * This function will fire anytime a post is updated.
+ * Including: the post status, comments, meta, terms, etc.
+ *
+ * @see https://developer.wordpress.org/reference/hooks/edit_post/
+ * @see https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#using-on-demand-revalidation
+ * @since 2.1.3
+ * @author WebDevStudios
+ * @param int $post_ID  The post ID.
+ * @param WP_Post $post The post object.
+ */
+function on_demand_revalidation( $post_ID, WP_Post $post ) {
+
+	// These constsants are required. If they're not here, bail...
+	if ( ! defined( 'HEADLESS_FRONTEND_URL' ) || ! defined( 'PREVIEW_SECRET_TOKEN' ) ) {
+		error_log( 'Missing constants for on demand revalidation.' );
+		return;
+	}
+
+	// No post ID? Bail...
+	if ( ! $post_ID ) {
+		error_log( 'Missing post ID for on demand revalidation.' );
+		return;
+	}
+
+	// Define the post slug and remove frontend URL.
+	$slug = str_replace( HEADLESS_FRONTEND_URL, '', get_the_permalink( $post_ID ) );
+
+	// No slug? Bail...
+	if ( ! $slug ) {
+		error_log( 'Missing post slug for on demand revalidation.' );
+		return;
+	}
+
+	// Send POST request to the frontend and revalidate the cache.
+	$response = wp_remote_post(
+		HEADLESS_FRONTEND_URL . 'api/wordpress/revalidate',
+		[
+			'blocking' => true,
+			'headers'  => [
+				'Content-Type' => 'application/json',
+				'Expect'       => '',
+			],
+			'body' => wp_json_encode(
+				[
+					'secret' => PREVIEW_SECRET_TOKEN,
+					'slug'   => "/${slug}",
+				]
+			),
+		]
+	);
+
+	// Check response code.
+	$response_code = wp_remote_retrieve_response_code( $response );
+
+	// If there is an error, log it.
+	if ( $response_code !== 200 ) {
+		error_log( 'Failed to revalidate cache for post ' . $slug . '.' );
+	}
+}
+add_action( 'edit_post', __NAMESPACE__ . '\on_demand_revalidation', 10, 3 );

--- a/wds-headless-core.php
+++ b/wds-headless-core.php
@@ -5,7 +5,7 @@
  * Description: The core WordPress plugin for the Next.js WordPress Starter.
  * Author: WebDevStudios <contact@webdevstudios.com>
  * Author URI: https://webdevstudios.com
- * Version: 2.1.3
+ * Version: 2.1.4
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * License: GPL-2
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define constants.
 define( 'WDS_HEADLESS_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WDS_HEADLESS_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-define( 'WDS_HEADLESS_CORE_VERSION', '2.1.3' );
+define( 'WDS_HEADLESS_CORE_VERSION', '2.1.4' );
 define( 'WDS_HEADLESS_CORE_OPTION_NAME', 'headless_config' );
 
 // Register de/activation hooks.
@@ -36,3 +36,4 @@ require_once 'inc/media.php';
 require_once 'inc/menus.php';
 require_once 'inc/settings.php';
 require_once 'inc/wp-graphql.php';
+require_once 'inc/revalidation.php';


### PR DESCRIPTION
- use `edit_post` hook to account for comments, meta, and terms updating
- move revalidation function into its own file for clarity