### PR TITLE
Require Acticvation and Deactivation files

### DIFF
--- a/wds-headless-core.php
+++ b/wds-headless-core.php
@@ -26,6 +26,9 @@ define( 'WDS_HEADLESS_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'WDS_HEADLESS_CORE_VERSION', '2.1.4' );
 define( 'WDS_HEADLESS_CORE_OPTION_NAME', 'headless_config' );
 
+require_once WDS_HEADLESS_CORE_PLUGIN_DIR . 'activation.php';
+require_once WDS_HEADLESS_CORE_PLUGIN_DIR . 'deactivation.php';
+
 // Register de/activation hooks.
 register_activation_hook( __FILE__, __NAMESPACE__ . '\activation_callback' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivation_callback' );


### PR DESCRIPTION
I'm hoping I can get some context on what's going on here. I'm reviewing the steps in the [backend setup](https://webdevstudios.github.io/nextjs-wordpress-starter/docs/backend) but was stopped short because I can't activate any of the core plugins. The error that comes up is because the activation hook function can't be found.

However, when I manually require the files, as I have done in this PR, the core plugins are able to activate/deactivate without a hitch.

I'm wondering if these should be included in all of the core plugins?